### PR TITLE
Improve pytest output on error

### DIFF
--- a/dist/pythonlibs/testrunner/pytest.py
+++ b/dist/pythonlibs/testrunner/pytest.py
@@ -31,20 +31,6 @@ TEST_LOG_CONSOLE = bool(int(os.environ.get('TEST_LOG_CONSOLE', '1')))
 TEST_TIMEOUT_ATTR = 'TIMEOUT'
 
 
-class CustomException(Exception):
-    pass
-
-
-@pytest.fixture(autouse=True)
-def patch_timeout(monkeypatch):
-
-    def _exception(self, err=None):
-        raise CustomException(err)
-
-    monkeypatch.setattr(pexpect.expect.Expecter, 'timeout', _exception)
-    monkeypatch.setattr(pexpect.expect.Expecter, 'eof', _exception)
-
-
 class CustomSpawn(pexpect.spawn):
 
     def __str__(self):
@@ -52,12 +38,9 @@ class CustomSpawn(pexpect.spawn):
 
     def expect(self, pattern, timeout=-1, searchwindowsize=-1, async=False,
                **kw):
-        try:
-            super(CustomSpawn, self).expect(
-                pattern, timeout=timeout, searchwindowsize=searchwindowsize,
-                async=async, **kw)
-        except CustomException:
-            raise
+        super(CustomSpawn, self).expect(
+              pattern, timeout=timeout, searchwindowsize=searchwindowsize,
+              async=async, **kw)
 
 
 @pytest.fixture(scope="module")

--- a/dist/pythonlibs/testrunner/pytest.py
+++ b/dist/pythonlibs/testrunner/pytest.py
@@ -32,13 +32,15 @@ TEST_TIMEOUT_ATTR = 'TIMEOUT'
 
 
 class CustomSpawn(pexpect.spawn):
+    """Convenient subclass to better catch pexpect timeout and eof errors."""
 
-    def expect(self, pattern, timeout=-1, searchwindowsize=-1, async=False,
+    def expect(self, pattern, timeout=-1, searchwindowsize=-1, async_=False,
                **kw):
+        # pylint:disable=arguments-differ
         try:
             super(CustomSpawn, self).expect(pattern, timeout=timeout,
                                             searchwindowsize=searchwindowsize,
-                                            async=async, **kw)
+                                            async=async_, **kw)
         except pexpect.TIMEOUT:
             error = traceback.format_stack()[-2]
             pytest.fail("Timeout in expect script at \"{}\"".format(error),
@@ -47,8 +49,6 @@ class CustomSpawn(pexpect.spawn):
             error = traceback.format_stack()[-2]
             pytest.fail("Unexpected end of file in expect script at "
                         "\"{}\"".format(error), pytrace=False)
-        except:
-            raise
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
I have something better now. Let me know what you think.

The output is now like this:
```
============================= test session starts ==============================
platform linux -- Python 3.6.7, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
rootdir: /home/aabadie/softs/src/riot/RIOT, inifile:
plugins: metadata-1.7.0, html-1.19.0
collected 1 item

tests/01-run.py make[2]: Nothing to be done for 'Makefile.include'.
/home/aabadie/softs/src/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf   
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
Cayenne LPP test application

Test 1:
-------
Result: 03670110056700FF SUCCESS

Test 2:
-------
Result: 0167FFD8067104D1FB2F0000
Expected: 0167FFD8067104D1FB2F0002 FAILED
F                                                        [100%]

=================================== FAILURES ===================================
___________________________________ testfunc ___________________________________
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 99, in expect_loop
    incoming = spawn.read_nonblocking(spawn.maxread, timeout)
  File "/usr/lib/python3/dist-packages/pexpect/pty_spawn.py", line 462, in read_nonblocking
    raise TIMEOUT('Timeout exceeded.')
pexpect.exceptions.TIMEOUT: Timeout exceeded.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aabadie/softs/src/riot/RIOT/tests/pkg_cayenne-lpp/tests/01-run.py", line 12, in testfunc
    child.expect('Result: [0-9A-Z]+ SUCCESS', timeout=2)
  File "/home/aabadie/softs/src/riot/RIOT/dist/pythonlibs/testrunner/pytest.py", line 58, in expect
    async=async, **kw)
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 321, in expect
    timeout, searchwindowsize, async)
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 345, in expect_list
    return exp.expect_loop(timeout)
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 107, in expect_loop
    return self.timeout(e)
  File "/home/aabadie/softs/src/riot/RIOT/dist/pythonlibs/testrunner/pytest.py", line 42, in _exception
    raise CustomException(err)
testrunner.pytest.CustomException: Timeout exceeded.
----------------------------- Captured stdout call -----------------------------
make[2]: Nothing to be done for 'Makefile.include'.
/home/aabadie/softs/src/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf   
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
Cayenne LPP test application

Test 1:
-------
Result: 03670110056700FF SUCCESS

Test 2:
-------
Result: 0167FFD8067104D1FB2F0000
Expected: 0167FFD8067104D1FB2F0002 FAILED
--------------------------- Captured stdout teardown ---------------------------

 generated xml file: /home/aabadie/softs/src/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/test_native.xml 
 generated html file: /home/aabadie/softs/src/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/test_native.html 
=========================== 1 failed in 5.54 seconds ===========================

```

Not perfect but readable.